### PR TITLE
Making it prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ def fold_function(acc, x):
 acc, num_samples = folded_sample_until(f, fold_function, (0, 0), duration_seconds=10, num_samples=100, num_workers=4)
 ```
 
-If using multiprocessing and sampling your function `f` is relatively fast, the aggregator process can sometimes not keep up with the incoming samples. Additionally, a lot of time is spent sending messages between the processes.
-Thus, it is often advantageous to not send every single sample to the aggregator process but send `batch_size` samples at once: 
+If using multiprocessing and sampling your function `f` is relatively fast, the folding process can sometimes not keep up with the incoming samples. Additionally, a lot of time is spent sending messages between the processes.
+Thus, it is often advantageous to not send every single sample to the folding process but send `batch_size` samples at once: 
 ```python
 acc, num_samples = folded_sample_until(f, fold_function, 0, duration_seconds=10, num_workers=4, batch_size=32)
 ```
-The batch is simply a list of samples that is then iterated by the aggregator.
-If aggregation is still too slow, you can implement the batches yourself using more performant structures, for example numpy arrays:
+The batch is simply a list of samples that is then iterated by the folding process.
+If folding is still too slow, you can implement the batches yourself using more performant structures, for example numpy arrays:
 
 ```python
 def f():
@@ -171,8 +171,8 @@ def folded_sample_until(
     i.e., `acc = fold_function(acc, f())` with initial value `acc = fold_initial`.
     For example, to sum up all outputs of `f`, the `fold_function(acc, x)` should return `acc + x`.
 
-    If `num_workers > 1`, there will be 1 aggregator process and `num_workers - 1` sampling processes
-    that send their generated samples to the aggregator process.
+    If `num_workers > 1`, there will be `1` folding process and `num_workers - 1` sampling processes
+    that send their generated samples to the folding process.
 
     Args:
         f: Function to sample.
@@ -183,7 +183,7 @@ def folded_sample_until(
         num_samples: Stop after number of samples acquired.
         memory_percentage: Stop after system memory exceeds percentage, e.g., `0.8`.
         num_workers: Number of processes. Pass `-1` for number of cpus.
-        batch_size: Only if num_workers > 1: send samples to aggregator process in batches.
+        batch_size: Only if num_workers > 1: send samples to folding process in batches.
 
     Returns:
         Accumulated result `acc` and number of iterations.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The wrapper function `sample_until` runs your function repeatedly until
 and collects the outputs in a list.
 Supports parallelized sampling via multiprocessing.
 
-The wrapper function `sample_until_folded` can be configured with the same stopping conditions as above,
+The wrapper function `folded_sample_until` can be configured with the same stopping conditions as above,
 but it accumulates the outputs using a user-defined `fold_function` instead of returning a list of samples.
 (For example, computing the sum over the outputs.)
 This is useful when the list of all samples would be too large to fit into memory.
@@ -74,14 +74,14 @@ samples = sample_until(h, f_args=itertools.cycle(rngs), duration_seconds=10, num
 ```
 As the 4 processes cycle through the `f_args`, each process uses a seperate `rng`.
 
-## Example Usage: `sample_until_folded`
+## Example Usage: `folded_sample_until`
 
 Sample for 10 seconds and compute the mean:
 ```python
 def fold_function(acc, x):
     return acc + x
 
-sum_samples, num_samples = sample_until_folded(f, fold_function, 0, duration_seconds=10)
+sum_samples, num_samples = folded_sample_until(f, fold_function, 0, duration_seconds=10)
 mean = sum_samples / num_samples
 ```
 
@@ -90,13 +90,13 @@ Stop sampling after either 10 seconds have passed or 100 samples have been acqui
 def fold_function(acc, x):
     return (acc[0] + x, acc[1] + x * x)
 
-acc, num_samples = sample_until_folded(f, fold_function, (0, 0), duration_seconds=10, num_samples=100, num_workers=4)
+acc, num_samples = folded_sample_until(f, fold_function, (0, 0), duration_seconds=10, num_samples=100, num_workers=4)
 ```
 
 If using multiprocessing and sampling your function `f` is relatively fast, the aggregator process can sometimes not keep up with the incoming samples. Additionally, a lot of time is spent sending messages between the processes.
 Thus, it is often advantageous to not send every single sample to the aggregator process but send `batch_size` samples at once: 
 ```python
-acc, num_samples = sample_until_folded(f, fold_function, 0, duration_seconds=10, num_workers=4, batch_size=32)
+acc, num_samples = folded_sample_until(f, fold_function, 0, duration_seconds=10, num_workers=4, batch_size=32)
 ```
 The batch is simply a list of samples that is then iterated by the aggregator.
 If aggregation is still too slow, you can implement the batches yourself using more performant structures, for example numpy arrays:
@@ -112,7 +112,7 @@ def fold_function(acc, x):
     # `x` is a np.ndarray
     return acc + np.sum(x)  # quicker than manual iteration
 
-acc, num_samples = sample_until_folded(f, fold_function, 0, duration_seconds=10)
+acc, num_samples = folded_sample_until(f, fold_function, 0, duration_seconds=10)
 ```
 
 ## Documentation
@@ -148,7 +148,7 @@ def sample_until(
 ```
 
 ```python
-def sample_until_folded(
+def folded_sample_until(
     f: Callable,
     fold_function: Callable,
     fold_initial: Any,

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ def sample_until(
     num_samples: Optional[int] = None,
     memory_percentage: Optional[float] = None,
     num_workers: int = 1,
+    verbose: bool = False,
 ) -> list:
     """
     Run `f` repeatedly until one of the given conditions is met and collect its outputs.
@@ -141,6 +142,7 @@ def sample_until(
         num_samples: Stop after number of samples acquired.
         memory_percentage: Stop after system memory exceeds percentage, e.g., `0.8`.
         num_workers: Number of processes. Pass `-1` for number of cpus.
+        verbose: Print due to which condition the sampling stopped.
 
     Returns:
         List of collected samples.
@@ -158,6 +160,7 @@ def folded_sample_until(
     memory_percentage: Optional[float] = None,
     num_workers: int = 1,
     batch_size: int = 1,
+    verbose: bool = False,
 ) -> tuple[Any, int]:
     """
     Run `f` repeatedly until one of the given conditions is met and aggregate its outputs.
@@ -184,6 +187,7 @@ def folded_sample_until(
         memory_percentage: Stop after system memory exceeds percentage, e.g., `0.8`.
         num_workers: Number of processes. Pass `-1` for number of cpus.
         batch_size: Only if num_workers > 1: send samples to folding process in batches.
+        verbose: Print due to which condition the sampling stopped.
 
     Returns:
         Accumulated result `acc` and number of iterations.

--- a/src/sample_until/__init__.py
+++ b/src/sample_until/__init__.py
@@ -1,2 +1,2 @@
 from .sample_until import sample_until
-from .sample_until_folded import sample_until_folded
+from .sample_until_folded import folded_sample_until

--- a/src/sample_until/sample_until.py
+++ b/src/sample_until/sample_until.py
@@ -88,7 +88,9 @@ def _sample_until(
         if stop(stopping_conditions, len(samples), verbose):
             return samples
 
-    print("Stopped because all f_args were used.")
+    if verbose:
+        print("Stopped because all f_args were used.")
+
     return samples
 
 

--- a/src/sample_until/sample_until.py
+++ b/src/sample_until/sample_until.py
@@ -13,6 +13,7 @@ def sample_until(
     num_samples: Optional[int] = None,
     memory_percentage: Optional[float] = None,
     num_workers: int = 1,
+    verbose: bool = False,
 ) -> list:
     """
     Run `f` repeatedly until one of the given conditions is met and collect its outputs.
@@ -30,6 +31,7 @@ def sample_until(
         num_samples: Stop after number of samples acquired.
         memory_percentage: Stop after system memory exceeds percentage, e.g., `0.8`.
         num_workers: Number of processes. Pass `-1` for number of cpus.
+        verbose: Print due to which condition the sampling stopped.
 
     Returns:
         List of collected samples.
@@ -40,7 +42,7 @@ def sample_until(
 
     # no multiprocessing
     if num_workers == 1:
-        return _sample_until(f1, f_args, stopping_conditions)
+        return _sample_until(f1, f_args, stopping_conditions, verbose)
 
     # multiprocessing
     manager = mp.Manager()
@@ -53,6 +55,7 @@ def sample_until(
                 islice(f_args, i, None, num_workers),
                 stopping_conditions,
                 output_queue,
+                verbose,
             ),
         )
         for i in range(num_workers)
@@ -76,12 +79,13 @@ def _sample_until(
     f: Callable,
     f_args: Iterable,
     stopping_conditions: list[StoppingCondition],
+    verbose: bool,
 ) -> list:
     samples = []
     for a in f_args:
         samples.append(f(a))
 
-        if stop(stopping_conditions, len(samples)):
+        if stop(stopping_conditions, len(samples), verbose):
             return samples
 
     print("Stopped because all f_args were used.")
@@ -93,6 +97,7 @@ def _worker(
     f_args: Iterable,
     stopping_conditions: list[StoppingCondition],
     output: mp.Queue,
+    verbose: bool,
 ):
-    local_samples = _sample_until(f, f_args, stopping_conditions)
+    local_samples = _sample_until(f, f_args, stopping_conditions, verbose)
     output.put(local_samples)

--- a/src/sample_until/sample_until_folded.py
+++ b/src/sample_until/sample_until_folded.py
@@ -6,6 +6,14 @@ from warnings import warn
 from .stopping_conditions import StoppingCondition, create_stopping_conditions, stop
 from .utils import check_fold_function, sanitize_inputs
 
+# TODO: Rename to folded_sample_until
+
+# TODO: Call it folding process everywhere, not aggregator process
+
+# TODO: Printing. (Verbose or not verbose)
+
+# TODO: prettier warnings
+
 
 class DoneSignal:
     pass

--- a/src/sample_until/sample_until_folded.py
+++ b/src/sample_until/sample_until_folded.py
@@ -6,8 +6,6 @@ from warnings import warn
 from .stopping_conditions import StoppingCondition, create_stopping_conditions, stop
 from .utils import check_fold_function, sanitize_inputs
 
-# TODO: Call it folding process everywhere, not aggregator process
-
 # TODO: Printing. (Verbose or not verbose)
 
 # TODO: prettier warnings
@@ -40,8 +38,8 @@ def folded_sample_until(
     i.e., `acc = fold_function(acc, f())` with initial value `acc = fold_initial`.
     For example, to sum up all outputs of `f`, the `fold_function(acc, x)` should return `acc + x`.
 
-    If `num_workers > 1`, there will be 1 aggregator process and `num_workers - 1` sampling processes
-    that send their generated samples to the aggregator process.
+    If `num_workers > 1`, there will be `1` folding process and `num_workers - 1` sampling processes
+    that send their generated samples to the folding process.
 
     Args:
         f: Function to sample.
@@ -52,7 +50,7 @@ def folded_sample_until(
         num_samples: Stop after number of samples acquired.
         memory_percentage: Stop after system memory exceeds percentage, e.g., `0.8`.
         num_workers: Number of processes. Pass `-1` for number of cpus.
-        batch_size: Only if num_workers > 1: send samples to aggregator process in batches.
+        batch_size: Only if num_workers > 1: send samples to folding process in batches.
 
     Returns:
         Accumulated result `acc` and number of iterations.

--- a/src/sample_until/sample_until_folded.py
+++ b/src/sample_until/sample_until_folded.py
@@ -6,8 +6,6 @@ from warnings import warn
 from .stopping_conditions import StoppingCondition, create_stopping_conditions, stop
 from .utils import check_fold_function, sanitize_inputs
 
-# TODO: prettier warnings
-
 
 class DoneSignal:
     pass
@@ -130,9 +128,11 @@ def folded_sample_until(
         if crashed:
             raise RuntimeError("Folding process crashed!")
         if not warned:
-            warn(
-                "Waiting for the folding process to finish folding. If the program does not terminate, check your folding function."
+            warn_msg = (
+                "Waiting for the folding process to finish. "
+                "If the program does not terminate, check your folding function."
             )
+            warn(warn_msg, RuntimeWarning)
             warned = True
 
 
@@ -171,9 +171,12 @@ def _aggregate(
 
     while finished_workers < num_workers:
         if not warned and output_queue.full():
-            warn(
-                "Accumulation queue is full! This indicates that the folding process can not keep up with the incoming samples. The sampling processes have to wait for free slots in the queue."
+            warn_msg = (
+                "Accumulation queue is full! "
+                "This indicates that the folding process can not keep up with the incoming samples. "
+                "The sampling processes have to wait for free slots in the queue."
             )
+            warn(warn_msg, RuntimeWarning)
             warned = True
         item = output_queue.get()
         if isinstance(item, DoneSignal):

--- a/src/sample_until/sample_until_folded.py
+++ b/src/sample_until/sample_until_folded.py
@@ -6,8 +6,6 @@ from warnings import warn
 from .stopping_conditions import StoppingCondition, create_stopping_conditions, stop
 from .utils import check_fold_function, sanitize_inputs
 
-# TODO: Rename to folded_sample_until
-
 # TODO: Call it folding process everywhere, not aggregator process
 
 # TODO: Printing. (Verbose or not verbose)
@@ -19,7 +17,7 @@ class DoneSignal:
     pass
 
 
-def sample_until_folded(
+def folded_sample_until(
     f: Callable,
     fold_function: Callable,
     fold_initial: Any,

--- a/src/sample_until/sample_until_folded.py
+++ b/src/sample_until/sample_until_folded.py
@@ -153,7 +153,8 @@ def _sample_until_folded(
         if stop(stopping_conditions, i, verbose):
             return acc, i
 
-    print("Stopped because all f_args were used.")
+    if verbose:
+        print("Stopped because all f_args were used.")
     return acc, i
 
 
@@ -211,6 +212,8 @@ def _worker(
                 output_queue.put(batch)
             return
 
-    print("Stopped because all f_args were used.")
+    if verbose:
+        print("Stopped because all f_args were used.")
+
     if len(batch) > 0:
         output_queue.put(batch)

--- a/src/sample_until/stopping_conditions.py
+++ b/src/sample_until/stopping_conditions.py
@@ -32,10 +32,15 @@ def create_stopping_conditions(
     return stopping_conditions
 
 
-def stop(stopping_conditions: list[StoppingCondition], num_samples: int) -> bool:
+def stop(
+    stopping_conditions: list[StoppingCondition],
+    num_samples: int,
+    verbose: bool = False,
+) -> bool:
     for sc in stopping_conditions:
         if sc.stop(num_samples):
-            print(sc.stop_message())
+            if verbose:
+                print(sc.stop_message())
             return True
     return False
 

--- a/tests/test_fold.py
+++ b/tests/test_fold.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sample_until import sample_until_folded
+from sample_until import folded_sample_until
 
 
 def sample(x):
@@ -17,29 +17,29 @@ def fold_sum(acc, x):
 
 
 def test_fold(f_args):
-    out = sample_until_folded(sample, fold_sum, 10, f_args=f_args)
+    out = folded_sample_until(sample, fold_sum, 10, f_args=f_args)
     assert out == (100 * 99 / 2 + 10, 100)
 
 
 def test_fold_stop_num_samples(f_args):
-    out = sample_until_folded(sample, fold_sum, 10, f_args=f_args, num_samples=50)
+    out = folded_sample_until(sample, fold_sum, 10, f_args=f_args, num_samples=50)
     assert out == (50 * 49 / 2 + 10, 50)
 
 
 def test_fold_multiprocessing(f_args):
-    out = sample_until_folded(sample, fold_sum, 10, f_args=f_args, num_workers=4)
+    out = folded_sample_until(sample, fold_sum, 10, f_args=f_args, num_workers=4)
     assert out == (100 * 99 / 2 + 10, 100)
 
 
 def test_fold_multiprocessing_stop_num_samples(f_args):
-    out = sample_until_folded(
+    out = folded_sample_until(
         sample, fold_sum, 10, f_args=f_args, num_samples=30, num_workers=4
     )
     assert out == (30 * 29 / 2 + 10, 30)
 
 
 def test_fold_multiprocessing_batches(f_args):
-    out = sample_until_folded(
+    out = folded_sample_until(
         sample, fold_sum, 10, f_args=f_args, num_workers=4, batch_size=8
     )
     assert out == (100 * 99 / 2 + 10, 100)
@@ -50,4 +50,4 @@ def test_fold_invalid_fold_function(f_args):
         return acc
 
     with pytest.raises(ValueError):
-        sample_until_folded(sample, invalid_fold, 0, f_args=f_args)
+        folded_sample_until(sample, invalid_fold, 0, f_args=f_args)


### PR DESCRIPTION
- rename `sample_until_folded` to `folded_sample_untI`
- verbose option
- documentation
- warnings